### PR TITLE
pc - workflow 33 should always publish artifacts to github pages

### DIFF
--- a/.github/workflows/33-frontend-pr-mutation-testing.yml
+++ b/.github/workflows/33-frontend-pr-mutation-testing.yml
@@ -52,13 +52,12 @@ jobs:
 
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2.27.0
-        continue-on-error: true
         with:
           workflow: 02-gh-pages-rebuild-part-1.yml
           github_token: ${{secrets.GITHUB_TOKEN}}
           branch: main
           name: stryker-incremental-${{env.pr_number}}.json
-          path: frontend/history/stryker-incremental-${{ env.pr_number }}.json
+          path: frontend/history
           check_artifacts: true
           if_no_artifact_found: warn
     
@@ -68,30 +67,24 @@ jobs:
       - run: npx stryker run --incremental --incrementalFile history/stryker-incremental-${{env.pr_number}}.json
         working-directory: ./frontend
 
-      - name: Debugging output two
-        run: |
-          ls -lRt frontend
-
       - name: Upload stryker incremental file to Artifacts
+        if: always() # always upload artifacts, even if tests fail
         uses: actions/upload-artifact@v3.1.2
         with:
           name: stryker-incremental-${{env.pr_number}}.json
           path: frontend/history/stryker-incremental-${{env.pr_number}}.json
 
       - name: Set path for github pages deploy when there is a PR num
-        if: ${{ env.pr_number != 'main' }}
+        if: always() # always upload artifacts, even if tests fail
         run: |
-          prefix="prs/${pr_number}/"
+          if [ "${{env.pr_number }}" = "main" ]; then
+             prefix=""
+          else
+             prefix="prs/${{ env.pr_number }}/"
+          fi
           echo "prefix=${prefix}"
           echo "prefix=${prefix}" >> "$GITHUB_ENV"
       
-      - name: Set path for github pages deploy when there is NOT a PR num
-        if: ${{ env.pr_number == 'main' }}
-        run: |
-          prefix=""
-          echo "prefix=${prefix}"
-          echo "prefix=${prefix}" >> "$GITHUB_ENV"
-
       - name: Deploy 🚀
         if: always() # always upload artifacts, even if tests fail
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
In this PR, we address a bug in workflow 33 where the artifacts were not being published to github pages for PRs if/when the mutation coverage is less than the set threshold.

This is not the desired behavior; when the mutation testing is less than the threshold, we want the report to be available on the GitHub pages site for easy reference, so that developers can more easily track down the problem without having to re-run the report (which is time-consuming; often taking 30 minutes to over an hour.)

Instead, we want the report that was *already generated* to be available for convenient browsing on the Github pages site associated with the repo.