### PR TITLE
Fix trivial stryker comments

### DIFF
--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -17,7 +17,7 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   // Stryker disable OptionalChaining
   const startQtr = systemInfo?.startQtrYYYYQ || "20211";
   const endQtr = systemInfo?.endQtrYYYYQ || "20214";
-  // Stryker enable OptionalChaining
+  // Stryker restore OptionalChaining
 
   const quarters = quarterRange(startQtr, endQtr);
 

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
@@ -17,7 +17,7 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
   // Stryker disable OptionalChaining
   const startQtr = systemInfo?.startQtrYYYYQ || "20211";
   const endQtr = systemInfo?.endQtrYYYYQ || "20214";
-  // Stryker enable OptionalChaining
+  // Stryker restore OptionalChaining
 
   const quarters = quarterRange(startQtr, endQtr);
 

--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -15,7 +15,7 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
     } = useForm(
         { defaultValues: initialCourse || {}, }
     );
-    // Stryker enable all
+    // Stryker restore all
 
     const navigate = useNavigate();
 

--- a/frontend/src/main/components/Courses/CourseTable.js
+++ b/frontend/src/main/components/Courses/CourseTable.js
@@ -12,7 +12,7 @@ export default function CourseTable({ courses, currentUser }) {
         { onSuccess: onDeleteSuccess },
         []
     );
-    // Stryker enable all
+    // Stryker restore all
     
     // Stryker disable next-line all : TODO try to make a good test for this
     const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }

--- a/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
@@ -15,7 +15,7 @@ const UpdateCoursesJobForm = ({ callback }) => {
   // Stryker disable OptionalChaining
   const startQtr = systemInfo?.startQtrYYYYQ || "20211";
   const endQtr = systemInfo?.endQtrYYYYQ || "20214";
-  // Stryker enable OptionalChaining
+  // Stryker restore OptionalChaining
 
   const quarters = quarterRange(startQtr, endQtr);
 

--- a/frontend/src/main/components/Sections/SectionsOverTimeTable.js
+++ b/frontend/src/main/components/Sections/SectionsOverTimeTable.js
@@ -15,7 +15,7 @@ function getCourseId(courseIds) {
 export default function SectionsOverTimeTable({ sections }) {
 
 
-    // Stryker enable all 
+    // Stryker restore all 
     // Stryker disable BooleanLiteral
     const columns = [
         {

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -11,7 +11,7 @@ function getFirstVal(values) {
 export default function SectionsTable({ sections }) {
 
 
-    // Stryker enable all 
+    // Stryker restore all 
     // Stryker disable BooleanLiteral
     const columns = [
         {

--- a/frontend/src/main/components/Utils/Plaintext.js
+++ b/frontend/src/main/components/Utils/Plaintext.js
@@ -18,5 +18,5 @@ export default function Plaintext({ text }) {
       }
     </pre>
   );
-  // Stryker enable StringLiteral
+  // Stryker restore StringLiteral
 }

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -67,7 +67,7 @@ export function useBackendMutation(objectToAxiosParams, useMutationParams, query
             if (queryKey !== null)
                 queryClient.invalidateQueries(queryKey);
         },
-        // Stryker enable all
+        // Stryker restore all
         retry: false,
         ...useMutationParams
     })


### PR DESCRIPTION
It should be `Stryker restore` not `Stryker enable`.

These changes do not introduce any surviving mutants which makes the change trivial. For the record, this introduces 31 new mutants from 1e550799 (930 -> 961). Other PRs will address non-trivial changes where more test coverage is needed.