### PR TITLE
pc - update workflow 33 to publish stryker report even if coverage is below 100%

### DIFF
--- a/.github/workflows/33-frontend-pr-mutation-testing.yml
+++ b/.github/workflows/33-frontend-pr-mutation-testing.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 40
     env:
       destination: frontend/reports/mutation
 


### PR DESCRIPTION
In this PR, we update workflow 33 so that even if the stryker report finds less than 100% coverage, the job will still push the report to Github Pages.

This will make it easier to see which mutants survived, and what new tests need to be written.