### PR TITLE
Change search by instructor query to be case insensitive

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -20,7 +20,7 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
         String endQuarter,
         String courseId );
 
-    @Query("{'courseInfo.quarter': {$gte: ?0, $lte: ?1}, 'section.instructors': { '$elemMatch': { 'instructor': { $regex: ?2 }}}}")
+    @Query("{'courseInfo.quarter': {$gte: ?0, $lte: ?1}, 'section.instructors': { '$elemMatch': { 'instructor': { $regex: ?2, $options: 'i' }}}}")
     List<ConvertedSection> findByQuarterRangeAndInstructor(
         String startQuarter,
         String endQuarter,


### PR DESCRIPTION
By request of @NateHoang. The alternative is having a headache of logic in the page/form, especially when factoring in autocomplete.