### PR TITLE
Revamp Course By Instructor Backend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -20,10 +20,11 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
         String endQuarter,
         String courseId );
 
-    @Query("{'courseInfo.quarter': {$gte: ?0, $lte: ?1}, 'section.instructors': { '$elemMatch': { 'instructor': { $regex: ?2 }}}}")
+    @Query("{'courseInfo.quarter': {$gte: ?0, $lte: ?1}, 'section.instructors': { '$elemMatch': { 'instructor': { $regex: ?2 }, 'functionCode': { $regex: ?3 }}}}")
     List<ConvertedSection> findByQuarterRangeAndInstructor(
         String startQuarter,
         String endQuarter,
-        String instructor );
+        String instructor,
+        String functionCode );
     
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseByInstructorController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseByInstructorController.java
@@ -33,16 +33,26 @@ public class CourseByInstructorController {
 	@ApiOperation(value = "Get a list of courses by instructor over time")
 	@GetMapping(value = "/search", produces = "application/json")
 	public ResponseEntity<String> search(
-			@ApiParam(name = "startQtr", type = "String", value = "Start quarter in YYYYQ format", example = "20221", required = true) @RequestParam String startQtr,
-			@ApiParam(name = "endQtr", type = "String", value = "End quarter in YYYYQ format", example = "20222", required = true) @RequestParam String endQtr,
-			@ApiParam(name = "instructor", type = "String", value = "Instructor name", example = "CONRAD P T", required = true) @RequestParam String instructor
-		)throws JsonProcessingException {
-		List<ConvertedSection> courseResults = convertedSectionCollection.findByQuarterRangeAndInstructor(
+		@ApiParam(name = "startQtr", type = "String", value = "Start quarter in YYYYQ format", example = "20221", required = true) @RequestParam String startQtr,
+		@ApiParam(name = "endQtr", type = "String", value = "End quarter in YYYYQ format", example = "20222", required = true) @RequestParam String endQtr,
+		@ApiParam(name = "instructor", type = "String", value = "Instructor name", example = "CONRAD P T", required = true) @RequestParam String instructor,
+		@ApiParam(name = "lectureOnly", type = "boolean", value = "Lectures only", example = "true", required = true) @RequestParam boolean lectureOnly
+	) throws JsonProcessingException {
+		List<ConvertedSection> courseResults;
+		if (lectureOnly) {
+			courseResults = convertedSectionCollection.findByQuarterRangeAndInstructor(
 				startQtr,
 				endQtr,
-				instructor);
+				"^"+instructor.toUpperCase(),
+				"^(Teaching and in charge)");
+		} else {
+			courseResults = convertedSectionCollection.findByQuarterRangeAndInstructor(
+				startQtr,
+				endQtr,
+				"^"+instructor.toUpperCase(),
+				"^.*");
+		}
 		String body = mapper.writeValueAsString(courseResults);
 		return ResponseEntity.ok().body(body);
 	}
-
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseByInstructorControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseByInstructorControllerTests.java
@@ -47,12 +47,12 @@ public class CourseByInstructorControllerTests {
     @Test
     public void test_search_emptyRequest() throws Exception {
         List<ConvertedSection> expectedResult = new ArrayList<ConvertedSection>();
-        String urlTemplate = "/api/public/coursebyinstructor/search?startQtr=%s&endQtr=%s&instructor=%s";
+        String urlTemplate = "/api/public/coursebyinstructor/search?startQtr=%s&endQtr=%s&instructor=%s&lectureOnly=%s";
         
-        String url = String.format(urlTemplate, "20222", "20212", "CONRAD P T");
+        String url = String.format(urlTemplate, "20222", "20212", "CONRAD P T", "false");
 
         // mock
-        when(convertedSectionCollection.findByQuarterRangeAndInstructor(any(String.class), any(String.class), any(String.class)))
+        when(convertedSectionCollection.findByQuarterRangeAndInstructor(any(String.class), any(String.class), any(String.class), any(String.class)))
             .thenReturn(expectedResult);
 
         // act
@@ -92,15 +92,56 @@ public class CourseByInstructorControllerTests {
             .section(section2)
             .build();
 
-        String urlTemplate = "/api/public/coursebyinstructor/search?startQtr=%s&endQtr=%s&instructor=%s";
+        String urlTemplate = "/api/public/coursebyinstructor/search?startQtr=%s&endQtr=%s&instructor=%s&lectureOnly=%s";
     
-        String url = String.format(urlTemplate, "20222", "20222", "CONRAD P T");
+        String url = String.format(urlTemplate, "20222", "20222", "CONRAD P T", "false");
 
         List<ConvertedSection> expectedSecs = new ArrayList<ConvertedSection>();
         expectedSecs.addAll(Arrays.asList(cs1, cs2));
 
         // mock
-        when(convertedSectionCollection.findByQuarterRangeAndInstructor(any(String.class), any(String.class), eq("CONRAD P T"))).thenReturn(expectedSecs);
+        when(convertedSectionCollection.findByQuarterRangeAndInstructor(any(String.class), any(String.class), eq("^CONRAD P T"), eq("^.*"))).thenReturn(expectedSecs);
+
+        // act
+        MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
+
+        // assert
+        String expectedString = mapper.writeValueAsString(expectedSecs);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedString, responseString);
+    }
+
+    @Test public void test_search_validRequestOnlyLectures() throws Exception {
+        CourseInfo info = CourseInfo.builder()
+            .quarter("20222")
+            .courseId("CMPSC   24 -1")
+            .title("OBJ ORIENTED DESIGN")
+            .description("Intro to object oriented design")
+            .build();
+        
+        Section section1 = new Section();
+
+        Section section2 = new Section();
+
+        ConvertedSection cs1 = ConvertedSection.builder()
+            .courseInfo(info)
+            .section(section1)
+            .build();
+        
+        ConvertedSection cs2 = ConvertedSection.builder()
+            .courseInfo(info)
+            .section(section2)
+            .build();
+
+        String urlTemplate = "/api/public/coursebyinstructor/search?startQtr=%s&endQtr=%s&instructor=%s&lectureOnly=%s";
+    
+        String url = String.format(urlTemplate, "20222", "20222", "CONRAD P T", "true");
+
+        List<ConvertedSection> expectedSecs = new ArrayList<ConvertedSection>();
+        expectedSecs.addAll(Arrays.asList(cs1, cs2));
+
+        // mock
+        when(convertedSectionCollection.findByQuarterRangeAndInstructor(any(String.class), any(String.class), eq("^CONRAD P T"), eq("^(Teaching and in charge)"))).thenReturn(expectedSecs);
 
         // act
         MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();


### PR DESCRIPTION
The search by instructor API endpoint is now case-insensitive, only matches from the start of the instructor's name, and allows for only viewing lectures. The query should be fast since it anchors at the beginning of the string and does not use regex's case insensitivity flag (which should be good for autocomplete).