### PR TITLE
Semi-fix sections over time table

### DIFF
--- a/frontend/src/main/components/Sections/SectionsOverTimeTable.js
+++ b/frontend/src/main/components/Sections/SectionsOverTimeTable.js
@@ -24,6 +24,9 @@ export default function SectionsOverTimeTable({ sections }) {
             disableGroupBy: true,
             id: 'quarter',
 
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`,
+
             Cell: ({ cell: { value } }) => value
 
         },

--- a/frontend/src/main/components/Sections/SectionsOverTimeTable.js
+++ b/frontend/src/main/components/Sections/SectionsOverTimeTable.js
@@ -31,6 +31,7 @@ export default function SectionsOverTimeTable({ sections }) {
             Header: 'Course ID',
             accessor: 'courseInfo.courseId',
             disableGroupBy: true,
+            id: 'courseID',
 
             aggregate: getCourseId,
             Aggregated: ({ cell: { value } }) => `${value}`,

--- a/frontend/src/main/components/SectionsOverTimeTableBase.js
+++ b/frontend/src/main/components/SectionsOverTimeTableBase.js
@@ -7,7 +7,7 @@ import { Table } from "react-bootstrap";
 export default function SectionsOverTimeTableBase({ columns, data, testid = "testid"}) {
   
   // Stryker disable next-line ObjectLiteral
-  const {getTableProps, getTableBodyProps, headerGroups, rows, prepareRow} = useTable({initialState: {groupBy: ["quarter"], hiddenColumns: ["isSection"]}, columns, data }, useGroupBy, useExpanded)
+  const {getTableProps, getTableBodyProps, headerGroups, rows, prepareRow} = useTable({initialState: {groupBy: ["courseID"], hiddenColumns: ["isSection"]}, columns, data }, useGroupBy, useExpanded)
 
   return (
     <Table {...getTableProps()} striped bordered hover >


### PR DESCRIPTION
Fixes a bug with the SectionsOverTimeTable that drops/miscategorizes courses. It's not bug-free, but it's better than before.

TODO: BEFORE

TODO: AFTER

Storybook entry: https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-2/prs/41/storybook/?path=/docs/components-sections-sectionsovertimetable--empty