### PR TITLE
pc - 30 minute timeout for pitest

### DIFF
--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v3.5.2


### PR DESCRIPTION
In this PR we change the default timeout for pitest to 30 minutes